### PR TITLE
[DM-27245] Arbitrary resource creation

### DIFF
--- a/dev-values.yaml
+++ b/dev-values.yaml
@@ -28,4 +28,9 @@ jupyterhub:
       nginx.ingress.kubernetes.io/auth-signin: "https://minikube.lsst.codes:31337/login"
       nginx.ingress.kubernetes.io/auth-url: "https://minikube.lsst.codes:31337/auth?scope=exec:notebook"
 
-config: {}
+config:
+  user_resources:
+    - apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: "{user}"

--- a/src/nublado2/hooks.py
+++ b/src/nublado2/hooks.py
@@ -1,7 +1,7 @@
 from jupyterhub.spawner import Spawner
 from traitlets.config import LoggingConfigurable
 
-from .resourcemgr import ResourceManager
+from nublado2.resourcemgr import ResourceManager
 
 
 class NubladoHooks(LoggingConfigurable):

--- a/src/nublado2/hooks.py
+++ b/src/nublado2/hooks.py
@@ -1,9 +1,19 @@
-# from jupyterhub.spawner import Spawner
-
 from jupyterhub.spawner import Spawner
 from traitlets.config import LoggingConfigurable
 
+from .resourcemgr import ResourceManager
+
 
 class NubladoHooks(LoggingConfigurable):
+    def __init__(self) -> None:
+        self.resourcemgr = ResourceManager()
+
     def pre_spawn(self, spawner: Spawner) -> None:
-        self.log.debug(f"Pre-spawn hook called for {spawner.user.name}")
+        user = spawner.user.name
+        self.log.debug(f"Pre-spawn hook called for {user}")
+        self.resourcemgr.create_user_resources(user)
+
+    def post_stop(self, spawner: Spawner) -> None:
+        user = spawner.user.name
+        self.log.debug(f"Post stop-hook called for {user}")
+        self.resourcemgr.delete_user_resources(user)

--- a/src/nublado2/hub_config.py
+++ b/src/nublado2/hub_config.py
@@ -22,6 +22,7 @@ class HubConfig(LoggingConfigurable):
         # Setup hooks
         hooks = NubladoHooks()
         c.Spawner.pre_spawn_hook = hooks.pre_spawn
+        c.Spawner.post_stop_hook = hooks.post_stop
 
         self.log.info("JupyterHub configuration complete")
         self.log.debug(f"JupyterHub configuration is now: {c}")

--- a/src/nublado2/resourcemgr.py
+++ b/src/nublado2/resourcemgr.py
@@ -3,7 +3,7 @@ from kubernetes import client, config
 from kubernetes.utils import create_from_dict
 from traitlets.config import LoggingConfigurable
 
-from .nublado_config import NubladoConfig
+from nublado2.nublado_config import NubladoConfig
 
 config.load_incluster_config()
 
@@ -22,7 +22,7 @@ class ResourceManager(LoggingConfigurable):
         resources = NubladoConfig().get().get("user_resources", [])
         for r in resources:
             templated_yaml = yaml.dump(r).format(**template_values)
-            templated_resource = yaml.load(templated_yaml, yaml.FullLoader)
+            templated_resource = yaml.load(templated_yaml, yaml.SafeLoader)
             self.log.debug(f"Creating resource:\n{templated_yaml}")
             create_from_dict(self.k8s_api, templated_resource)
 

--- a/src/nublado2/resourcemgr.py
+++ b/src/nublado2/resourcemgr.py
@@ -1,0 +1,33 @@
+import yaml
+from kubernetes import client, config
+from kubernetes.utils import create_from_dict
+from traitlets.config import LoggingConfigurable
+
+from .nublado_config import NubladoConfig
+
+config.load_incluster_config()
+
+
+class ResourceManager(LoggingConfigurable):
+    # These k8s clients don't copy well with locks, connection,
+    # pools, locks, etc.  Copying seems to happen under the hood of the
+    # LoggingConfigurable base class, so just have them be class variables.
+    # Should be safe to share these, and better to have fewer of them.
+    k8s_api = client.api_client.ApiClient()
+    k8s_client = client.CoreV1Api()
+
+    def create_user_resources(self, user: str) -> None:
+        template_values = {"user": user}
+
+        resources = NubladoConfig().get().get("user_resources", [])
+        for r in resources:
+            templated_yaml = yaml.dump(r).format(**template_values)
+            templated_resource = yaml.load(templated_yaml, yaml.FullLoader)
+            self.log.debug(f"Creating resource:\n{templated_yaml}")
+            create_from_dict(self.k8s_api, templated_resource)
+
+    def delete_user_resources(self, user: str) -> None:
+        # TODO: the namespace should probably be cleaned up by the
+        # multinamespace kubespawner, but this is how to delete the
+        # namespace this way.  We might not even have to fill in this hook.
+        self.k8s_client.delete_namespace(name=user)


### PR DESCRIPTION
In the dev-values.yaml there's an example of a namespace of the user
getting created after filling in the name and sending it to k8s.

On stop, we also clean it up.  This is just an example of how we
can create resources with just the yaml, and not call specific APIs
based on different resource types.