### PR TITLE
[DM-27278] Get gafaelfawr auth working on minikube

### DIFF
--- a/dev-values.yaml
+++ b/dev-values.yaml
@@ -26,7 +26,7 @@ jupyterhub:
     hosts: ["minikube.lsst.codes"]
     annotations:
       nginx.ingress.kubernetes.io/auth-signin: "https://minikube.lsst.codes:31337/login"
-      nginx.ingress.kubernetes.io/auth-url: "https://minikube.lsst.codes:31337/auth?scope=exec:notebook"
+      nginx.ingress.kubernetes.io/auth-url: "http://gafaelfawr-service.gafaelfawr.svc.cluster.local:8080/auth?scope=exec:notebook"
 
 config:
   user_resources:


### PR DESCRIPTION
So the short version of this long story is that you can't access
minikube.lsst.codes since it's a private IP address.  This works
on int and stable, because it actually contacts the public address,
which just happens to be the local cluster.  But it doesn't use the
local IP address, unless you refer to it like this.