### PR TITLE
[DM-28482] Get lab spawning

### DIFF
--- a/dev-values.yaml
+++ b/dev-values.yaml
@@ -48,7 +48,7 @@ config:
       - name: Large
         cpu: 4
         ram: 12288M
-  use_auth_uid: False
+  pod_uid: 769
   user_resources:
     - apiVersion: v1
       kind: Namespace

--- a/dev-values.yaml
+++ b/dev-values.yaml
@@ -69,9 +69,154 @@ config:
         SODA_ROUTE: /api/image/soda
         WORKFLOW_ROUTE: /wf
         AUTO_REPO_URLS: https://github.com/lsst-sqre/notebook-demo
-        NO_SUDO: "true"
-        EXTERNAL_GROUPS: "{{groups}}"
+        EXTERNAL_GROUPS: "{{external_groups}}"
         EXTERNAL_UID: "{{uid}}"
         ACCESS_TOKEN: "{{token}}"
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: group
+        namespace: "n2-dev-{{user}}"
+      data:
+        group: |
+          root:x:0:
+          bin:x:1:
+          daemon:x:2:
+          sys:x:3:
+          adm:x:4:
+          tty:x:5:
+          disk:x:6:
+          lp:x:7:
+          mem:x:8:
+          kmem:x:9:
+          wheel:x:10:
+          cdrom:x:11:
+          mail:x:12:
+          man:x:15:
+          dialout:x:18:
+          floppy:x:19:
+          games:x:20:
+          tape:x:33:
+          video:x:39:
+          ftp:x:50:
+          lock:x:54:
+          audio:x:63:
+          nobody:x:99:
+          users:x:100:
+          utmp:x:22:
+          utempter:x:35:
+          input:x:999:
+          systemd-journal:x:190:
+          systemd-network:x:192:
+          dbus:x:81:
+          ssh_keys:x:998:
+          lsst_lcl:x:1000:{{user}}
+          tss:x:59:
+          cgred:x:997:
+          screen:x:84:
+          jovyan:x:768:{{user}}
+          provisionator:x:769:
+          {{user}}:x:{{uid}}:{% for group in groups %}
+          {{ group }}:x:{{ gids[loop.index]}}:{{ user }}{% endfor %}
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: gshadow
+        namespace: "n2-dev-{{user}}"
+      data:
+        gshadow: |
+          root:!::
+          bin:!::
+          daemon:!::
+          sys:!::
+          adm:!::
+          tty:!::
+          disk:!::
+          lp:!::
+          mem:!::
+          kmem:!::
+          wheel:!::
+          cdrom:!::
+          mail:!::
+          man:!::
+          dialout:!::
+          floppy:!::
+          games:!::
+          tape:!::
+          video:!::
+          ftp:!::
+          lock:!::
+          audio:!::
+          nobody:!::
+          users:!::
+          utmp:!::
+          utempter:!::
+          input:!::
+          systemd-journal:!::
+          systemd-network:!::
+          dbus:!::
+          ssh_keys:!::
+          lsst_lcl:!::{{user}}
+          tss:!::
+          cgred:!::
+          screen:!::
+          jovyan:!::{{user}}
+          provisionator:!::
+          {{user}}:!::{% for g in groups %}
+          {{ g }}:!::{{ user }}{% endfor %}
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: passwd
+        namespace: "n2-dev-{{user}}"
+      data:
+        passwd: |
+          root:x:0:0:root:/root:/bin/bash
+          bin:x:1:1:bin:/bin:/sbin/nologin
+          daemon:x:2:2:daemon:/sbin:/sbin/nologin
+          adm:x:3:4:adm:/var/adm:/sbin/nologin
+          lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+          sync:x:5:0:sync:/sbin:/bin/sync
+          shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+          halt:x:7:0:halt:/sbin:/sbin/halt
+          mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
+          operator:x:11:0:operator:/root:/sbin/nologin
+          games:x:12:100:games:/usr/games:/sbin/nologin
+          ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
+          nobody:x:99:99:Nobody:/:/sbin/nologin
+          systemd-network:x:192:192:systemd Network Management:/:/sbin/nologin
+          dbus:x:81:81:System message bus:/:/sbin/nologin
+          lsst_lcl:x:1000:1000::/home/lsst_lcl:/bin/bash
+          tss:x:59:59:Account used by the trousers package to sandbox the tcsd daemon:/dev/null:/sbin/nologin
+          provisionator:x:769:769:Lab provisioning user:/home/provisionator:/bin/bash
+          {{user}}:x:{{uid}}:{{uid}}::/home/{{user}}:/bin/bash
+    - apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        name: shadow
+        namespace: "n2-dev-{{user}}"
+      data:
+        shadow: |
+          root:*:18000:0:99999:7:::
+          bin:*:18000:0:99999:7:::
+          daemon:*:18000:0:99999:7:::
+          adm:*:18000:0:99999:7:::
+          lp:*:18000:0:99999:7:::
+          sync:*:18000:0:99999:7:::
+          shutdown:*:18000:0:99999:7:::
+          halt:*:18000:0:99999:7:::
+          mail:*:18000:0:99999:7:::
+          operator:*:18000:0:99999:7:::
+          games:*:18000:0:99999:7:::
+          ftp:*:18000:0:99999:7:::
+          nobody:*:18000:0:99999:7:::
+          systemd-network:*:18000:0:99999:7:::
+          dbus:*:18000:0:99999:7:::
+          lsst_lcl:*:18000:0:99999:7:::
+          tss:*:18000:0:99999:7:::
+          provisionator:*:18000:0:99999:7:::
+          {{user}}:*:18000:0:99999:7:::
+
+
 
 vault_secret_path: "secret/k8s_operator/minikube.lsst.codes/nublado2"

--- a/src/nublado2/hooks.py
+++ b/src/nublado2/hooks.py
@@ -38,8 +38,15 @@ class NubladoHooks(LoggingConfigurable):
 
         auth_state = await spawner.user.get_auth_state()
 
+        # Should we spawn with the uid of the user (from the auth state)
+        # or the provisioner (769) which will then sudo and become the
+        # user?
         if nc.use_auth_uid():
             spawner.uid = auth_state["uid"]
+            spawner.gid = auth_state["uid"]
+        else:
+            spawner.uid = 769
+            spawner.gid = 769
 
         await self.resourcemgr.create_user_resources(spawner.user)
 

--- a/src/nublado2/hooks.py
+++ b/src/nublado2/hooks.py
@@ -41,12 +41,13 @@ class NubladoHooks(LoggingConfigurable):
         # Should we spawn with the uid of the user (from the auth state)
         # or the provisioner (769) which will then sudo and become the
         # user?
-        if nc.use_auth_uid():
+        pod_uid = nc.pod_uid()
+        if pod_uid:
+            spawner.uid = pod_uid
+            spawner.gid = pod_uid
+        else:
             spawner.uid = auth_state["uid"]
             spawner.gid = auth_state["uid"]
-        else:
-            spawner.uid = 769
-            spawner.gid = 769
 
         await self.resourcemgr.create_user_resources(spawner.user)
 

--- a/src/nublado2/hub_config.py
+++ b/src/nublado2/hub_config.py
@@ -39,12 +39,6 @@ class HubConfig(LoggingConfigurable):
             "envFrom": [{"configMapRef": {"name": "lab-environment"}}]
         }
 
-        # The zero-to-jupyterhub charts normally set the command to
-        # jupyterlab-singleuser, and override what the command is for
-        # the docker container.  If you set cmd = None, this means use
-        # the default command for the docker container entrypoint.
-        c.KubeSpawner.cmd = None
-
         self.log.info("JupyterHub configuration complete")
         self.log.debug(f"JupyterHub configuration is now: {c}")
 

--- a/src/nublado2/hub_config.py
+++ b/src/nublado2/hub_config.py
@@ -39,6 +39,12 @@ class HubConfig(LoggingConfigurable):
             "envFrom": [{"configMapRef": {"name": "lab-environment"}}]
         }
 
+        # The zero-to-jupyterhub charts normally set the command to
+        # jupyterlab-singleuser, and override what the command is for
+        # the docker container.  If you set cmd = None, this means use
+        # the default command for the docker container entrypoint.
+        c.KubeSpawner.cmd = None
+
         self.log.info("JupyterHub configuration complete")
         self.log.debug(f"JupyterHub configuration is now: {c}")
 

--- a/src/nublado2/nublado_config.py
+++ b/src/nublado2/nublado_config.py
@@ -2,7 +2,7 @@
 
 __all__ = ["NubladoConfig"]
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import yaml
 from traitlets.config import LoggingConfigurable
@@ -25,5 +25,5 @@ class NubladoConfig(LoggingConfigurable):
 
         raise ValueError(f"Size {name} not found")
 
-    def use_auth_uid(self) -> bool:
-        return self.get().get("use_auth_uid", True)
+    def pod_uid(self) -> Optional[int]:
+        return self.get().get("pod_uid", None)

--- a/src/nublado2/resourcemgr.py
+++ b/src/nublado2/resourcemgr.py
@@ -27,11 +27,22 @@ class ResourceManager(LoggingConfigurable):
             auth_state = await user.get_auth_state()
             self.log.debug(f"Auth state={auth_state}")
 
+            groups = auth_state["groups"]
+            gids = auth_state["gids"]
+
+            # Build a comma separated list of group:gid
+            # ex: group1:1000,group2:1001,group3:1002
+            external_groups = ",".join(
+                [f"{group}:{gid}" for group, gid in zip(groups, gids)]
+            )
+
             template_values = {
                 "user": user.name,
                 "uid": auth_state["uid"],
                 "token": auth_state["token"],
-                "groups": ",".join(auth_state["groups"]),
+                "groups": groups,
+                "gids": gids,
+                "external_groups": external_groups,
                 "base_url": NubladoConfig().get().get("base_url"),
             }
 


### PR DESCRIPTION
Set the uid to the provisioner and make sure to run the default entrypoint of the container, and not the default, which is apparently jupyterlab-singleuser.

This also adds and gets the group work ready for mounting those different configmaps when we want to not run as root and want to run as the uid.  Right now these work and are created as expected, but aren't used or mounted yet.