### PR TITLE
[DM-28666] Combine group and GIDs into one data structure

### DIFF
--- a/dev-values.yaml
+++ b/dev-values.yaml
@@ -117,7 +117,7 @@ config:
           jovyan:x:768:{{user}}
           provisionator:x:769:
           {{user}}:x:{{uid}}:{% for group in groups %}
-          {{ group }}:x:{{ gids[loop.index]}}:{{ user }}{% endfor %}
+          {{ group.name }}:x:{{ group.id }}:{{ user }}{% endfor %}
     - apiVersion: v1
       kind: ConfigMap
       metadata:
@@ -163,7 +163,7 @@ config:
           jovyan:!::{{user}}
           provisionator:!::
           {{user}}:!::{% for g in groups %}
-          {{ g }}:!::{{ user }}{% endfor %}
+          {{ g.name }}:!::{{ user }}{% endfor %}
     - apiVersion: v1
       kind: ConfigMap
       metadata:

--- a/src/nublado2/auth.py
+++ b/src/nublado2/auth.py
@@ -173,12 +173,7 @@ class GafaelfawrLoginHandler(BaseHandler):
         uid = token_data.get("uidNumber")
         try:
             groups = [
-                g["name"]
-                for g in token_data.get("isMemberOf", [])
-                if "id" in g
-            ]
-            gids = [
-                int(g["id"])
+                {"name": g["name"], "id": int(g["id"])}
                 for g in token_data.get("isMemberOf", [])
                 if "id" in g
             ]
@@ -190,6 +185,5 @@ class GafaelfawrLoginHandler(BaseHandler):
                 "uid": int(uid) if uid else None,
                 "token": token,
                 "groups": groups,
-                "gids": gids,
             },
         }

--- a/src/nublado2/resourcemgr.py
+++ b/src/nublado2/resourcemgr.py
@@ -24,12 +24,11 @@ class ResourceManager(LoggingConfigurable):
             self.log.debug(f"Auth state={auth_state}")
 
             groups = auth_state["groups"]
-            gids = auth_state["gids"]
 
             # Build a comma separated list of group:gid
             # ex: group1:1000,group2:1001,group3:1002
             external_groups = ",".join(
-                [f"{group}:{gid}" for group, gid in zip(groups, gids)]
+                [f'{g["name"]}:{g["id"]}' for g in groups]
             )
 
             template_values = {
@@ -38,7 +37,6 @@ class ResourceManager(LoggingConfigurable):
                 "uid": auth_state["uid"],
                 "token": auth_state["token"],
                 "groups": groups,
-                "gids": gids,
                 "external_groups": external_groups,
                 "base_url": NubladoConfig().get().get("base_url"),
             }

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -96,7 +96,6 @@ async def test_login_handler() -> None:
                     "uid": None,
                     "token": "some-token",
                     "groups": [],
-                    "gids": [],
                 },
             }
 
@@ -108,8 +107,8 @@ async def test_login_handler() -> None:
                     "uidNumber": "4510",
                     "isMemberOf": [
                         {"name": "group-one", "id": 1726},
-                        {"name": "group-two", "id": 1618},
-                        {"name": "another", "id": 6789},
+                        {"name": "group-two", "id": "1618"},
+                        {"name": "another", "id": 6789, "foo": "bar"},
                     ],
                 }
             )
@@ -119,8 +118,11 @@ async def test_login_handler() -> None:
                 "auth_state": {
                     "uid": 4510,
                     "token": "some-token",
-                    "groups": ["group-one", "group-two", "another"],
-                    "gids": [1726, 1618, 6789],
+                    "groups": [
+                        {"name": "group-one", "id": 1726},
+                        {"name": "group-two", "id": 1618},
+                        {"name": "another", "id": 6789},
+                    ],
                 },
             }
 
@@ -152,7 +154,9 @@ async def test_login_handler() -> None:
                 "auth_state": {
                     "uid": 4510,
                     "token": "some-token",
-                    "groups": ["group-one", "another"],
-                    "gids": [1726, 6789],
+                    "groups": [
+                        {"name": "group-one", "id": 1726},
+                        {"name": "another", "id": 6789},
+                    ],
                 },
             }


### PR DESCRIPTION
Don't require code using the authentication information to zip
together groups and GIDs or have to implicitly assume the two
lists are parallel.  Instead, store group information as a list of
dicts with name and ID attributes.  Adjust the dev templates
accordingly.