### PR TITLE
[DM-29084] Update Docker and pre-commit CI configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,18 +1,27 @@
 name: CI
 
-on: [push]
+"on": [push]
 
 jobs:
   test:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        python:
+          - 3.7
+          - 3.9
+
     steps:
       - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v2.2.1
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: ${{ matrix.python }}
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v2.0.0
 
       - name: Install tox
         run: pip install tox
@@ -22,49 +31,63 @@ jobs:
         uses: actions/cache@v2
         with:
           path: .tox
-          # requirements/*.txt, pyproject.toml, and .pre-commit-config.yaml
-          # have versioning info that would impact the tox environment.
-          key: tox-${{ hashFiles('requirements/*.txt') }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('.pre-commit-config.yaml') }}
+          # requirements/*.txt and pyproject.toml have versioning info
+          # that would impact the tox environment.
+          key: tox-${{ matrix.python }}-${{ hashFiles('requirements/*.txt') }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            tox-${{ matrix.python }}-${{ hashFiles('requirements/*.txt') }}-
 
       - name: Run tox
-        run: tox -e lint,py,coverage-report,typing  # run tox using Python in path
+        run: tox -e py,coverage-report,typing
 
   build:
     runs-on: ubuntu-latest
     needs: [test]
+
+    # Only do Docker builds of ticket branches and tagged releases.
+    if: startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/tickets/')
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Define the Docker tag
         id: vars
-        run: echo ::set-output name=tag::$(echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g')
+        run: echo ::set-output name=tag::$(scripts/docker-tag.sh "$GITHUB_REF")
 
       - name: Print the tag
         id: print
-        run: echo ${{steps.vars.outputs.tag}}
+        run: echo ${{ steps.vars.outputs.tag }}
 
-      - name: Log into Docker Hub
-        run: echo ${{ secrets.DOCKER_TOKEN }} | docker login --username ${{ secrets.DOCKER_USERNAME }} --password-stdin
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
 
-      - name: Pull previous images
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys:
+            ${{ runner.os }}-buildx-
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: lsstsqre/nublado2:${{ steps.vars.outputs.tag }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
         run: |
-          docker pull lsstsqre/nublado2:deps-${{steps.vars.outputs.tag}} || true
-          docker pull lsstsqre/nublado2:${{steps.vars.outputs.tag}} || true
-
-      - name: Build the dependencies Docker image
-        run: |
-          docker build --target dependencies-image \
-            --cache-from=lsstsqre/nublado2:deps-${{steps.vars.outputs.tag}} \
-            --tag lsstsqre/nublado2:deps-${{steps.vars.outputs.tag}} .
-
-      - name: Build the runtime Docker image
-        run: |
-          docker build --target runtime-image \
-            --cache-from=lsstsqre/nublado2:${{steps.vars.outputs.tag}} \
-            --tag lsstsqre/nublado2:${{steps.vars.outputs.tag}} .
-
-      - name: Push Docker images
-        run: |
-          docker push lsstsqre/nublado2:deps-${{steps.vars.outputs.tag}}
-          docker push lsstsqre/nublado2:${{steps.vars.outputs.tag}}
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/scripts/docker-tag.sh
+++ b/scripts/docker-tag.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Determine the tag for Docker images.  Takes the Git ref as its only
+# argument.
+
+set -eo pipefail
+
+if [ -z "$1" ]; then
+    echo 'Usage: scripts/docker-tag.sh $GITHUB_REF' >&2
+    exit 1
+fi
+
+echo "$1" | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'


### PR DESCRIPTION
Only build Docker images for tagged releases and ticket branches.
Use the official Docker actions, and use a script to determine the
Docker tag.

Use the pre-commit action instead of running pre-commit with tox
to get the benefit of pre-commit environment caching.