### PR TITLE
[DM-29799] Pass in hub address to user resource template

### DIFF
--- a/src/nublado2/resourcemgr.py
+++ b/src/nublado2/resourcemgr.py
@@ -67,6 +67,7 @@ class ResourceManager(LoggingConfigurable):
                 "options": options,
                 "labels": spawner.common_labels,
                 "annotations": spawner.extra_annotations,
+                "nublado_base_url": spawner.hub.base_url,
             }
 
             self.log.debug(f"Template values={template_values}")


### PR DESCRIPTION
This will make it so that we don't have to have the URL in multiple
places, we can just use what the hub says it is.