### PR TITLE
[DM-28120] Fix parsing of cachemachine entries without hashes

### DIFF
--- a/src/nublado2/imageinfo.py
+++ b/src/nublado2/imageinfo.py
@@ -53,7 +53,7 @@ class ImageInfo:
         return cls(
             reference=entry["image_url"],
             display_name=entry["name"],
-            digest=(entry["image_hash"] or ""),
+            digest=entry.get("image_hash", ""),
         )
 
     @classmethod

--- a/tests/imageinfo_test.py
+++ b/tests/imageinfo_test.py
@@ -33,6 +33,16 @@ def test_creation_from_cachemachine_entry() -> None:
     assert img.digest == TEST_DIGEST
 
 
+def test_creation_without_hash() -> None:
+    """Create from a dict like we'd get from cachemachine but with no hash."""
+    entry = dict(**TEST_ENTRY)
+    del entry["image_hash"]
+    img = ImageInfo.from_cachemachine_entry(entry)
+    assert img.reference == TEST_REF
+    assert img.display_name == TEST_DISPLAY_NAME
+    assert img.digest == ""
+
+
 def test_roundtrip() -> None:
     """Create an object from a cachemachine entry, get its packed string,
     create a new object from that, and test that the fields are the same."""


### PR DESCRIPTION
Entries without hashes (such as on NCSA) were causing a KeyError
exception instead of being replaced with the empty string as
intended.