### PR TITLE
[DM-28120] Fix cachemachine parsing of None hashes

### DIFF
--- a/src/nublado2/imageinfo.py
+++ b/src/nublado2/imageinfo.py
@@ -1,11 +1,11 @@
 from dataclasses import dataclass
-from typing import Dict
+from typing import Mapping, Optional
 
 FIELD_DELIMITER = "|"
 
 # This type is the dict that comes from cachemachine:
 #  https: //github.com/lsst-sqre/cachemachine/blob/4802ab7d78aec27b400f66b9af3324180910476e/src/cachemachine/types.py#L50-L69  # noqa: E501
-CachemachineEntry = Dict[str, str]
+CachemachineEntry = Mapping[str, Optional[str]]
 
 
 @dataclass(frozen=True)
@@ -51,9 +51,9 @@ class ImageInfo:
         """
         # entry uses None, we use empty string for missing digest
         return cls(
-            reference=entry["image_url"],
-            display_name=entry["name"],
-            digest=entry.get("image_hash", ""),
+            reference=entry["image_url"] or "",
+            display_name=entry["name"] or "",
+            digest=entry.get("image_hash", "") or "",
         )
 
     @classmethod

--- a/tests/imageinfo_test.py
+++ b/tests/imageinfo_test.py
@@ -1,6 +1,8 @@
 """Tests for the ImageInfo class.
 """
 
+from typing import Dict, Optional
+
 from nublado2.imageinfo import FIELD_DELIMITER, ImageInfo
 
 TEST_REF = "registry.hub.docker.com/lsstsqre/sciplat-lab:test_version"
@@ -35,8 +37,15 @@ def test_creation_from_cachemachine_entry() -> None:
 
 def test_creation_without_hash() -> None:
     """Create from a dict like we'd get from cachemachine but with no hash."""
-    entry = dict(**TEST_ENTRY)
+    entry: Dict[str, Optional[str]] = dict(**TEST_ENTRY)
     del entry["image_hash"]
+    img = ImageInfo.from_cachemachine_entry(entry)
+    assert img.reference == TEST_REF
+    assert img.display_name == TEST_DISPLAY_NAME
+    assert img.digest == ""
+
+    # The same but with a hash of None.
+    entry["image_hash"] = None
     img = ImageInfo.from_cachemachine_entry(entry)
     assert img.reference == TEST_REF
     assert img.display_name == TEST_DISPLAY_NAME


### PR DESCRIPTION
The previous fix handled image_hash being absent entirely, but the
more common case is for image_hash to be set to null in the JSON.
Handle that similarly and map it to the empty string.