### PR TITLE
Accept user resource templates as dicts

### DIFF
--- a/src/nublado2/nublado_config.py
+++ b/src/nublado2/nublado_config.py
@@ -69,14 +69,9 @@ class NubladoConfig:
         return dict(self._sizes)
 
     @property
-    def user_resources_template(self) -> str:
+    def user_resources_template(self) -> Dict[str, Any]:
         """Retrieve a copy of the lab resources templates."""
         return self._config.get("user_resources_template")
-
-    @property
-    def custom_resources_template(self) -> str:
-        """Retrieve a copy of the lab custom resource templates."""
-        return self._config.get("custom_resources_template")
 
     @property
     def volumes(self) -> List[Dict[str, Any]]:

--- a/src/nublado2/resourcemgr.py
+++ b/src/nublado2/resourcemgr.py
@@ -1,10 +1,11 @@
+from io import StringIO
+
 import aiohttp
 from jinja2 import Template
 from jupyterhub.spawner import Spawner
 from kubernetes import client, config
 from kubernetes.utils import create_from_dict
-from ruamel import yaml
-from ruamel.yaml import RoundTripLoader
+from ruamel.yaml import YAML
 from traitlets.config import LoggingConfigurable
 
 from nublado2.crdparser import CRDParser
@@ -30,85 +31,91 @@ class ResourceManager(LoggingConfigurable):
             headers={"Authorization": f"Bearer {token}"}
         )
         self.provisioner = Provisioner(self.http_client)
+        self.yaml = YAML()
+        self.yaml.indent(mapping=2, sequence=4, offset=2)
 
     async def create_user_resources(
         self, spawner: Spawner, options: SelectedOptions
     ) -> None:
         """Create the user resources for this spawning session."""
         await self.provisioner.provision_homedir(spawner)
-
         try:
-            auth_state = await spawner.user.get_auth_state()
-            self.log.debug(f"Auth state={auth_state}")
-            groups = auth_state["groups"]
-
-            # Build a comma separated list of group:gid
-            # ex: group1:1000,group2:1001,group3:1002
-            external_groups = ",".join(
-                [f'{g["name"]}:{g["id"]}' for g in groups]
+            dask_template = await self._build_dask_template(spawner)
+            await self._create_kubernetes_resources(
+                spawner, options, dask_template
             )
-
-            # Retrieve image tag and corresponding hash (if any)
-            # These come back from the options form as one-item lists
-
-            template_values = {
-                "user_namespace": spawner.namespace,
-                "user": spawner.user.name,
-                "uid": auth_state["uid"],
-                "token": auth_state["token"],
-                "groups": groups,
-                "external_groups": external_groups,
-                "base_url": self.nublado_config.base_url,
-                "dask_yaml": await self._build_dask_template(spawner),
-                "options": options,
-                "labels": spawner.common_labels,
-                "annotations": spawner.extra_annotations,
-                "nublado_base_url": spawner.hub.base_url,
-                "butler_secret_path": self.nublado_config.butler_secret_path,
-            }
-
-            self.log.debug(f"Template values={template_values}")
-            self.log.debug("Template:")
-            self.log.debug(self.nublado_config.user_resources_template)
-            t = Template(self.nublado_config.user_resources_template)
-            templated_user_resources = t.render(template_values)
-            self.log.debug("Generated user resources:")
-            self.log.debug(templated_user_resources)
-
-            user_resources = yaml.load(
-                templated_user_resources, Loader=RoundTripLoader
-            )
-
-            for r in user_resources:
-                self.log.debug(f"Creating: {r}")
-                create_from_dict(self.k8s_api, r)
         except Exception:
             self.log.exception("Exception creating user resource!")
             raise
-        try:
-            # CRDs cannot be created with create_from_dict:
+
+    async def _create_kubernetes_resources(
+        self, spawner: Spawner, options: SelectedOptions, dask_template: str
+    ) -> None:
+        auth_state = await spawner.user.get_auth_state()
+        self.log.debug(f"Auth state={auth_state}")
+        groups = auth_state["groups"]
+
+        # Build a comma separated list of group:gid
+        # ex: group1:1000,group2:1001,group3:1002
+        external_groups = ",".join([f'{g["name"]}:{g["id"]}' for g in groups])
+
+        # Use Jinja2 to substitute the following values into the templates.
+        template_values = {
+            "user_namespace": spawner.namespace,
+            "user": spawner.user.name,
+            "uid": auth_state["uid"],
+            "token": auth_state["token"],
+            "groups": groups,
+            "external_groups": external_groups,
+            "base_url": self.nublado_config.base_url,
+            "dask_yaml": dask_template,
+            "options": options,
+            "nublado_base_url": spawner.hub.base_url,
+            "butler_secret_path": self.nublado_config.butler_secret_path,
+        }
+        self.log.debug(f"Template values={template_values}")
+
+        # Each resource appears in our ConfigMap and thus in nublado_config as
+        # a dict representing the YAML of the resource we want to generate,
+        # but possibly containing Jinja2 templating instructions. To template
+        # that with Jinja2, we have to convert it back to its textual
+        # representation, run the template engine on it, and then turn it back
+        # into a dict.
+        templates = self.nublado_config.user_resources_template
+        for template_yaml in templates.values():
+            template_stream = StringIO()
+            self.yaml.dump(template_yaml, template_stream)
+            template_str = template_stream.getvalue()
+            self.log.debug(f"Template:\n{template_str}")
+            template = Template(template_str)
+            resource_str = template.render(template_values)
+            self.log.debug(f"Generated resource:\n{resource_str}")
+            resource = self.yaml.load(resource_str)
+
+            # Add in the standard labels and annotations common to every
+            # resource.
+            if "metadata" not in resource:
+                resource["metadata"] = {}
+            resource["metadata"]["annotations"] = spawner.extra_annotations
+            resource["metadata"]["labels"] = spawner.common_labels
+
+            # Custom resources cannot be created by create_from_dict:
             # https://github.com/kubernetes-client/python/issues/740
-            ct = Template(self.nublado_config.custom_resources_template)
-            templated_custom_resources = ct.render(template_values)
-            self.log.debug("Generated custom resources:")
-            self.log.debug(templated_custom_resources)
-            custom_resources = yaml.load(
-                templated_custom_resources, Loader=RoundTripLoader
-            )
-            for cr in custom_resources:
-                self.log.debug(f"Creating: {cr}")
-                crd_parser = CRDParser.from_crd_body(cr)
-                self.log.debug(f"CRD_Parser: {crd_parser}")
+            #
+            # Detect those from the apiVersion field and handle them
+            # specially.
+            api_version = resource["apiVersion"]
+            if "." in api_version and ".k8s.io/" not in api_version:
+                crd_parser = CRDParser.from_crd_body(resource)
                 self.custom_api.create_namespaced_custom_object(
-                    body=cr,
+                    body=resource,
                     group=crd_parser.group,
                     version=crd_parser.version,
                     namespace=spawner.namespace,
                     plural=crd_parser.plural,
                 )
-        except Exception:
-            self.log.exception("Exception creating custom resource!")
-            raise
+            else:
+                create_from_dict(self.k8s_api, resource)
 
     async def _build_dask_template(self, spawner: Spawner) -> str:
         """Build a template for dask workers from the jupyter pod manifest."""
@@ -131,7 +138,7 @@ class ResourceManager(LoggingConfigurable):
         # This will take the python model names and transform
         # them to the names kubernetes expects, which to_dict
         # alone doesn't.
-        dask_yaml = yaml.dump(
+        dask_yaml = self.yaml.dump(
             self.k8s_api.sanitize_for_serialization(dask_template)
         )
 


### PR DESCRIPTION
In order to allow selective overrides of parts of the user
resource templates via values files in Phalanx, we want to configure
and store them in the Nublado ConfigMap as dicts.  This requires
some additional logic to convert them to text before running them
through Jinja2 for templating (which avoids having to iterate
through every leaf value to see if it needs to be templated).

Switch to the new ruaml.yaml API, since the old one is deprecated.

Detect whether a given resource is a custom resource or not, rather
than forcing the caller to separate the resources into two different
configuration options.