### PR TITLE
[DM-30180] Use extra_labels instead of common_labels

### DIFF
--- a/src/nublado2/resourcemgr.py
+++ b/src/nublado2/resourcemgr.py
@@ -69,7 +69,7 @@ class ResourceManager(LoggingConfigurable):
                 name="lab-environment",
                 namespace=spawner.namespace,
                 annotations=spawner.extra_annotations,
-                labels=spawner.common_labels,
+                labels=spawner.extra_labels,
             ),
             data=environment,
         )
@@ -95,7 +95,7 @@ class ResourceManager(LoggingConfigurable):
             if "metadata" not in resource:
                 resource["metadata"] = {}
             resource["metadata"]["annotations"] = spawner.extra_annotations
-            resource["metadata"]["labels"] = spawner.common_labels
+            resource["metadata"]["labels"] = spawner.extra_labels
 
             # Custom resources cannot be created by create_from_dict:
             # https://github.com/kubernetes-client/python/issues/740

--- a/tests/resourcemgr_test.py
+++ b/tests/resourcemgr_test.py
@@ -154,7 +154,7 @@ async def test_create_kubernetes_resources(
         "argocd.argoproj.io/compare-options": "IgnoreExtraneous",
         "argocd.argoproj.io/sync-options": "Prune=false",
     }
-    spawner.common_labels = {
+    spawner.extra_labels = {
         "hub.jupyter.org/network-access-hub": "true",
         "argocd.argoproj.io/instance": "nublado-users",
     }
@@ -217,7 +217,7 @@ async def test_create_kubernetes_resources(
                 "name": "dask",
                 "namespace": spawner.namespace,
                 "annotations": spawner.extra_annotations,
-                "labels": spawner.common_labels,
+                "labels": spawner.extra_labels,
             },
             "data": {
                 "dask_worker.yml": f"""\
@@ -246,7 +246,7 @@ spec:
                 "name": "group",
                 "namespace": spawner.namespace,
                 "annotations": spawner.extra_annotations,
-                "labels": spawner.common_labels,
+                "labels": spawner.extra_labels,
             },
             "data": {
                 "group": (
@@ -263,7 +263,7 @@ spec:
                 "name": "lab-environment",
                 "namespace": spawner.namespace,
                 "annotations": spawner.extra_annotations,
-                "labels": spawner.common_labels,
+                "labels": spawner.extra_labels,
             },
             "data": {
                 "EXTERNAL_INSTANCE_URL": "https://data.example.com/",
@@ -291,7 +291,7 @@ spec:
                 "name": "butler-secret",
                 "namespace": spawner.namespace,
                 "annotations": spawner.extra_annotations,
-                "labels": spawner.common_labels,
+                "labels": spawner.extra_labels,
             },
             "spec": {
                 "path": "k8s_operator/data/butler",


### PR DESCRIPTION
So, common labels are handled a bit weird, and I was confused.
In the zero to jupyterhub chart, there's some code that takes
the common labels and makes them from the helm data.

Extralabels, on the other hand, is a different property that
is being set, and we should use that instead.  If we ever want
to get to configuring the labels differently for different
resources, then we'll need to add that part of the templating
back in the resource string, but until then, this should be fine.