### PR TITLE
[DM-31947] Stop overriding entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,3 @@ WORKDIR /home/jovyan
 USER jovyan
 EXPOSE 8000
 EXPOSE 8081
-ENTRYPOINT ["jupyterhub", "--config", "/etc/jupyterhub/jupyterhub_config.py"]


### PR DESCRIPTION
So, in the newer helm chart, it mounts the jupyterhub_config.py
in /usr/local now instead of /etc.  And it fixed whatever issue
with the entrypoint which was the reason I overrode it in the first
place.  So now we can get rid of this.  If we don't, then jupyterhub
ends up confused since both get passed in somehow and then it errors
out.