### PR TITLE
[DM-32551] Force refresh of auth state

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,19 @@
 name: CI
 
-"on": [push]
+"on":
+  push:
+    branches-ignore:
+      # These should always correspond to pull requests, so ignore them for
+      # the push trigger and let them be triggered by the pull_request
+      # trigger, avoiding running the workflow twice.  This is a minor
+      # optimization so there's no need to ensure this is comprehensive.
+      - "dependabot/**"
+      - "renovate/**"
+      - "tickets/**"
+      - "u/**"
+    tags:
+      - "*"
+  pull_request: {}
 
 jobs:
   test:
@@ -44,15 +57,23 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
 
-    # Only do Docker builds of ticket branches and tagged releases.
-    if: startsWith(github.ref, 'refs/tags/') || startsWith(github.ref, 'refs/heads/tickets/')
+    # Only do Docker builds of tagged releases and pull requests from ticket
+    # branches.  This will still trigger on pull requests from untrusted
+    # repositories whose branch names match our tickets/* branch convention,
+    # but in this case the build will fail with an error since the secret
+    # won't be set.
+    if: >
+      startsWith(github.ref, 'refs/tags/')
+      || startsWith(github.head_ref, 'tickets/')
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Define the Docker tag
         id: vars
-        run: echo ::set-output name=tag::$(scripts/docker-tag.sh "$GITHUB_REF")
+        run: echo ::set-output name=tag::$(scripts/docker-tag.sh)
 
       - name: Print the tag
         id: print

--- a/scripts/docker-tag.sh
+++ b/scripts/docker-tag.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 
-# Determine the tag for Docker images.  Takes the Git ref as its only
-# argument.
+# Determine the tag for Docker images based on GitHub Actions environment
+# variables.
 
 set -eo pipefail
 
-if [ -z "$1" ]; then
-    echo 'Usage: scripts/docker-tag.sh $GITHUB_REF' >&2
-    exit 1
+if [ -n "$GITHUB_HEAD_REF" ]; then
+    # For pull requests
+    echo ${GITHUB_HEAD_REF} | sed -E 's,/,-,g'
+else
+    # For push events
+    echo ${GITHUB_REF} | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'
 fi
-
-echo "$1" | sed -E 's,refs/(heads|tags)/,,' | sed -E 's,/,-,g'

--- a/src/nublado2/auth.py
+++ b/src/nublado2/auth.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
     from jupyterhub.app import JupyterHub
+    from jupyterhub.user import User
     from tornado.httputil import HTTPHeaders
     from tornado.web import RequestHandler
 
@@ -65,7 +66,7 @@ class GafaelfawrAuthenticator(Authenticator):
     authenticate the user "in place" in the handler of whatever page the user
     first went to, without any redirects.  This would be slightly more
     efficient and the code appears to handle it, but the current documentation
-    (as of 1.1.0) explicitly says to not override ``get_authenticated_user``.
+    (as of 1.5.0) explicitly says to not override ``get_authenticated_user``.
 
     This implementation therefore takes the well-documented path of a new
     handler and a redirect from the built-in login handler, on the theory that
@@ -108,6 +109,12 @@ class GafaelfawrAuthenticator(Authenticator):
         case).
         """
         return url_path_join(base_url, "gafaelfawr/login")
+
+    async def refresh_user(
+        self, user: User, handler: Optional[RequestHandler] = None
+    ) -> bool:
+        """Tell JupyterHub to always refresh the user's token."""
+        return False
 
 
 class GafaelfawrLoginHandler(BaseHandler):

--- a/src/nublado2/auth.py
+++ b/src/nublado2/auth.py
@@ -114,6 +114,11 @@ class GafaelfawrAuthenticator(Authenticator):
         self, user: User, handler: Optional[RequestHandler] = None
     ) -> bool:
         """Tell JupyterHub to always refresh the user's token."""
+        if handler:
+            token = handler.request.headers.get("X-Auth-Request-Token")
+            if token:
+                auth_state = await user.get_auth_state()
+                return token == auth_state["token"]
         return False
 
 

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -15,7 +15,11 @@ from aioresponses import CallbackResult, aioresponses
 from tornado import web
 from tornado.httputil import HTTPHeaders
 
-from nublado2.auth import GafaelfawrAuthenticator, GafaelfawrLoginHandler
+from nublado2.auth import (
+    GafaelfawrAuthenticator,
+    GafaelfawrLoginHandler,
+    _build_auth_info,
+)
 
 if TYPE_CHECKING:
     from typing import Any, AsyncGenerator, Callable, Dict
@@ -57,25 +61,25 @@ async def test_login_handler(config_mock: MagicMock) -> None:
     # No headers.
     with aioresponses() as m:
         with pytest.raises(web.HTTPError):
-            await GafaelfawrLoginHandler._build_auth_info(HTTPHeaders())
+            await _build_auth_info(HTTPHeaders())
 
     # Invalid token.
     with aioresponses() as m:
         m.get(url, status=403)
         with pytest.raises(web.HTTPError):
-            await GafaelfawrLoginHandler._build_auth_info(headers)
+            await _build_auth_info(headers)
 
     # Bad API response payload.
     with aioresponses() as m:
         m.get(url, payload={}, status=200)
         with pytest.raises(web.HTTPError):
-            await GafaelfawrLoginHandler._build_auth_info(headers)
+            await _build_auth_info(headers)
 
     # Test minimum data.
     with aioresponses() as m:
         handler = build_userinfo_handler({"username": "foo", "uid": 1234})
         m.get(url, callback=handler)
-        assert await GafaelfawrLoginHandler._build_auth_info(headers) == {
+        assert await _build_auth_info(headers) == {
             "name": "foo",
             "auth_state": {
                 "username": "foo",
@@ -98,7 +102,7 @@ async def test_login_handler(config_mock: MagicMock) -> None:
             }
         )
         m.get(url, callback=handler)
-        assert await GafaelfawrLoginHandler._build_auth_info(headers) == {
+        assert await _build_auth_info(headers) == {
             "name": "bar",
             "auth_state": {
                 "username": "bar",


### PR DESCRIPTION
Setting refresh_pre_spawn only calls refresh_user, which by default
does nothing.  Override it to refresh the user based on the headers
of the current request.

This should fix the problem of JupyterHub hanging on to old expired
tokens and continuing to mount them in pods.

Also update the Docker image and CI configuration for our current
standard.