### PR TITLE
[DM-31621] Update CI, Docker, and dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,8 +22,9 @@ jobs:
     strategy:
       matrix:
         python:
-          - 3.8
-          - 3.9
+          - "3.8"
+          - "3.9"
+          - "3.10"
 
     steps:
       - uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
-FROM jupyterhub/jupyterhub:1.4 as base-image
+FROM jupyterhub/jupyterhub:1.5.0 as base-image
 
 # Update system packages
 COPY scripts/install-base-packages.sh .
-RUN ./install-base-packages.sh
+RUN ./install-base-packages.sh && rm install-base-packages.sh
 
 FROM base-image as dependencies-image
+
+# Install system packages only needed for building dependencies.
+COPY scripts/install-dependency-packages.sh .
+RUN ./install-dependency-packages.sh && rm install-dependency-packages.sh
 
 # Install the app's Python runtime dependencies
 COPY requirements/main.txt ./requirements.txt

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -10,15 +10,7 @@
 aioresponses
 pre-commit
 coverage[toml]
-flake8
 mypy
 pytest
 pytest-asyncio
 tornado
-
-# Add an explicit dependency on ruamel.yaml.clib to generate hashes when
-# the requirements file is rebuilt on Python 3.9.  It's not required for
-# Python 3.9, but is for Python 3.7, and without this dependency,
-# installation will fail on Python 3.7.  This is a transitive dependency
-# from jupyterhub -> jupyter-telemetry.
-ruamel.yaml.clib

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -174,10 +174,6 @@ filelock==3.4.0 \
     --hash=sha256:2e139a228bcf56dd8b2274a65174d005c4a6b68540ee0bdbb92c76f43f29f7e8 \
     --hash=sha256:93d512b32a23baf4cac44ffd72ccf70732aeff7b8050fcaf6d3ec406d954baf4
     # via virtualenv
-flake8==4.0.1 \
-    --hash=sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d \
-    --hash=sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d
-    # via -r requirements/dev.in
 frozenlist==1.2.0 \
     --hash=sha256:01d79515ed5aa3d699b05f6bdcf1fe9087d61d6b53882aa599a10853f0479c6c \
     --hash=sha256:0a7c7cce70e41bc13d7d50f0e5dd175f14a4f1837a8549b0936ed0cbe6170bf9 \
@@ -269,10 +265,6 @@ iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
     # via pytest
-mccabe==0.6.1 \
-    --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
-    --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
-    # via flake8
 multidict==5.2.0 \
     --hash=sha256:06560fbdcf22c9387100979e65b26fba0816c162b888cb65b845d3def7a54c9b \
     --hash=sha256:067150fad08e6f2dd91a650c7a49ba65085303fcc3decbd64a57dc13a2733031 \
@@ -395,22 +387,14 @@ pluggy==1.0.0 \
     --hash=sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159 \
     --hash=sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3
     # via pytest
-pre-commit==2.15.0 \
-    --hash=sha256:3c25add78dbdfb6a28a651780d5c311ac40dd17f160eb3954a0c59da40a505a7 \
-    --hash=sha256:a4ed01000afcb484d9eb8d504272e642c4c4099bbad3a6b27e519bd6a3e928a6
+pre-commit==2.16.0 \
+    --hash=sha256:758d1dc9b62c2ed8881585c254976d66eae0889919ab9b859064fc2fe3c7743e \
+    --hash=sha256:fe9897cac830aa7164dbd02a4e7b90cae49630451ce88464bca73db486ba9f65
     # via -r requirements/dev.in
 py==1.11.0 \
     --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
     --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
     # via pytest
-pycodestyle==2.8.0 \
-    --hash=sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20 \
-    --hash=sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f
-    # via flake8
-pyflakes==2.4.0 \
-    --hash=sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c \
-    --hash=sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e
-    # via flake8
 pyparsing==3.0.6 \
     --hash=sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4 \
     --hash=sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81
@@ -462,31 +446,6 @@ pyyaml==6.0 \
     # via
     #   -c requirements/main.txt
     #   pre-commit
-ruamel.yaml.clib==0.2.6 \
-    --hash=sha256:0847201b767447fc33b9c235780d3aa90357d20dd6108b92be544427bea197dd \
-    --hash=sha256:1866cf2c284a03b9524a5cc00daca56d80057c5ce3cdc86a52020f4c720856f0 \
-    --hash=sha256:31ea73e564a7b5fbbe8188ab8b334393e06d997914a4e184975348f204790277 \
-    --hash=sha256:3fb9575a5acd13031c57a62cc7823e5d2ff8bc3835ba4d94b921b4e6ee664104 \
-    --hash=sha256:4ff604ce439abb20794f05613c374759ce10e3595d1867764dd1ae675b85acbd \
-    --hash=sha256:72a2b8b2ff0a627496aad76f37a652bcef400fd861721744201ef1b45199ab78 \
-    --hash=sha256:78988ed190206672da0f5d50c61afef8f67daa718d614377dcd5e3ed85ab4a99 \
-    --hash=sha256:7b2927e92feb51d830f531de4ccb11b320255ee95e791022555971c466af4527 \
-    --hash=sha256:7f7ecb53ae6848f959db6ae93bdff1740e651809780822270eab111500842a84 \
-    --hash=sha256:825d5fccef6da42f3c8eccd4281af399f21c02b32d98e113dbc631ea6a6ecbc7 \
-    --hash=sha256:846fc8336443106fe23f9b6d6b8c14a53d38cef9a375149d61f99d78782ea468 \
-    --hash=sha256:89221ec6d6026f8ae859c09b9718799fea22c0e8da8b766b0b2c9a9ba2db326b \
-    --hash=sha256:9efef4aab5353387b07f6b22ace0867032b900d8e91674b5d8ea9150db5cae94 \
-    --hash=sha256:a32f8d81ea0c6173ab1b3da956869114cae53ba1e9f72374032e33ba3118c233 \
-    --hash=sha256:a49e0161897901d1ac9c4a79984b8410f450565bbad64dbfcbf76152743a0cdb \
-    --hash=sha256:ada3f400d9923a190ea8b59c8f60680c4ef8a4b0dfae134d2f2ff68429adfab5 \
-    --hash=sha256:bf75d28fa071645c529b5474a550a44686821decebdd00e21127ef1fd566eabe \
-    --hash=sha256:cfdb9389d888c5b74af297e51ce357b800dd844898af9d4a547ffc143fa56751 \
-    --hash=sha256:d67f273097c368265a7b81e152e07fb90ed395df6e552b9fa858c6d2c9f42502 \
-    --hash=sha256:dc6a613d6c74eef5a14a214d433d06291526145431c3b964f5e16529b1842bed \
-    --hash=sha256:de9c6b8a1ba52919ae919f3ae96abb72b994dd0350226e28f3686cb4f142165c
-    # via
-    #   -c requirements/main.txt
-    #   -r requirements/dev.in
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
@@ -549,9 +508,9 @@ tornado==6.1 \
     # via
     #   -c requirements/main.txt
     #   -r requirements/dev.in
-typing-extensions==4.0.0 \
-    --hash=sha256:2cdf80e4e04866a9b3689a51869016d36db0814d84b8d8a568d22781d45d27ed \
-    --hash=sha256:829704698b22e13ec9eaf959122315eabb370b0884400e9818334d8b677023d9
+typing-extensions==4.0.1 \
+    --hash=sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e \
+    --hash=sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b
     # via
     #   -c requirements/main.txt
     #   async-timeout

--- a/requirements/main.in
+++ b/requirements/main.in
@@ -8,20 +8,20 @@
 aiohttp
 aiodns
 cchardet
-importlib_metadata
-importlib-resources
 inflect
 jinja2
-jupyterhub
 jupyterhub-idle-culler
 jupyterhub-kubespawner
 psycopg2
 ruamel.yaml
 tornado
 
-# Add an explicit dependency on importlib-resources to generate hashes when
-# the requirements file is rebuilt on Python 3.9.  It's not required for
-# Python 3.9, but is for Python 3.7, and without this dependency,
-# installation will fail on Python 3.7.  This is a transitive dependency
-# from jupyterhub -> alembic.
+# Always pin jupyterhub to a specific version.  We don't want it to be
+# upgraded without our explicit approval, and it should be upgraded in
+# lockstep with the base image in Dockerfile.
+jupyterhub==1.5.0
+
+# Required by alembic for Python 3.8, so install it unconditionally until
+# Python 3.8 support is dropped so that we have consistent dependencies.
+importlib-metadata
 importlib-resources

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -421,9 +421,9 @@ jupyterhub-kubespawner==2.0.0 \
     --hash=sha256:55846d3e8a3daf35ab703144111388e08832c0f1552a6b598e52e213934768c3 \
     --hash=sha256:57bb84b050851455e7a56e2667a358173b68ecb4b9c16f7d2bea9e0858dd3725
     # via -r requirements/main.in
-kubernetes==19.15.0 \
-    --hash=sha256:08c93f300a9837104282ecc81458b903a56444c5c1ec3d990d237557312af47f \
-    --hash=sha256:52312adda60d92ba45b325f2c1505924656389222005f7e089718e1ad03bc07f
+kubernetes==20.13.0 \
+    --hash=sha256:7d32ea7f555813a141a0e912e7695d88f7213bb632a860ba79a963b43f7a6b18 \
+    --hash=sha256:ce5e881c13dc56f21a243804f90bc3c507af93c380f505c00e392c823968e4de
     # via jupyterhub-kubespawner
 mako==1.1.6 \
     --hash=sha256:4e9e345a41924a954251b95b4b28e14a301145b544901332e658907a7464b6b2 \
@@ -879,9 +879,9 @@ traitlets==5.1.1 \
     # via
     #   jupyter-telemetry
     #   jupyterhub
-typing-extensions==4.0.0 \
-    --hash=sha256:2cdf80e4e04866a9b3689a51869016d36db0814d84b8d8a568d22781d45d27ed \
-    --hash=sha256:829704698b22e13ec9eaf959122315eabb370b0884400e9818334d8b677023d9
+typing-extensions==4.0.1 \
+    --hash=sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e \
+    --hash=sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b
     # via async-timeout
 urllib3==1.26.7 \
     --hash=sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece \

--- a/scripts/install-base-packages.sh
+++ b/scripts/install-base-packages.sh
@@ -27,7 +27,7 @@ apt-get update
 apt-get -y upgrade
 
 # Example of installing a new package, without unnecessary packages:
-apt-get -y install --no-install-recommends git libpq-dev gcc python3-dev
+apt-get -y install --no-install-recommends git
 
 # Delete cached files we don't need anymore:
 apt-get clean

--- a/scripts/install-dependency-packages.sh
+++ b/scripts/install-dependency-packages.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# This script installs additional packages used by the dependency image but
+# not needed by the runtime image, such as additional packages required to
+# build Python dependencies.
+#
+# Since the base image wipes all the apt caches to clean up the image that
+# will be reused by the runtime image, we unfortunately have to do another
+# apt-get update here, which wastes some time and network.
+
+# Bash "strict mode", to help catch problems and bugs in the shell
+# script. Every bash script you write should include this. See
+# http://redsymbol.net/articles/unofficial-bash-strict-mode/ for
+# details.
+set -euo pipefail
+
+# Display each command as it's run.
+set -x
+
+# Tell apt-get we're never going to be able to give manual
+# feedback:
+export DEBIAN_FRONTEND=noninteractive
+
+# Update the package listing, so we know what packages exist:
+apt-get update
+
+# Install build-essential because sometimes Python dependencies need to build
+# C modules, particularly when upgrading to newer Python versions.  libffi-dev
+# is sometimes needed to build cffi (a cryptography dependency).  libpq-dev
+# and python3-dev are required to build psycopg2
+apt-get -y install --no-install-recommends build-essential libffi-dev \
+    libpq-dev python3-dev
+
+# Delete cached files we don't need anymore:
+apt-get clean
+rm -rf /var/lib/apt/lists/*

--- a/src/nublado2/__init__.py
+++ b/src/nublado2/__init__.py
@@ -2,13 +2,7 @@
 
 __all__ = ["__version__", "metadata"]
 
-import sys
-
-if sys.version_info < (3, 8):
-    from importlib_metadata import PackageNotFoundError, version
-else:
-    from importlib.metadata import PackageNotFoundError, version
-
+from importlib.metadata import PackageNotFoundError, version
 
 __version__: str
 """The application version string of (PEP 440 / SemVer compatible)."""


### PR DESCRIPTION
Reflect changes to the templates by updating the GitHub CI
configuration, the Docker build configuration, and the dependency
declarations.  This will allow CI runs on pull requests, but there
should otherwise not be any significant functionality changes.

Restore explicit pin of jupyterhub to 1.5.0, which apparently was
what was in the last release, and update the Dockerfile base image
to match.