### PR TITLE
[DM-26506] Derive cachemachine URL from base URL

### DIFF
--- a/dev-values.yaml
+++ b/dev-values.yaml
@@ -32,7 +32,6 @@ jupyterhub:
 config:
   base_url: "https://minikube.lsst.codes"
   butler_secret_path: "secret/k8s_operator/minikube.lsst.codes/butler-secret"
-  images_url: "http://cachemachine.cachemachine.svc.cluster.local/cachemachine/jupyter/available"
   volumes:
     - name: home
       emptyDir: {}

--- a/src/nublado2/nublado_config.py
+++ b/src/nublado2/nublado_config.py
@@ -43,13 +43,6 @@ class NubladoConfig:
             return None
 
     @property
-    def images_url(self) -> str:
-        """URL to fetch list of images to show in options form.
-
-        Generally, this is a link to the cachemachine service."""
-        return self._config["images_url"]
-
-    @property
     def lab_environment(self) -> Dict[str, str]:
         """Environment variable settings for the lab (possibly templates)."""
         return dict(self._config.get("lab_environment", {}))

--- a/src/nublado2/options.py
+++ b/src/nublado2/options.py
@@ -1,4 +1,9 @@
+"""Spawner option form handling."""
+
+from __future__ import annotations
+
 from typing import List, Optional, Tuple
+from urllib.parse import urljoin
 
 from jinja2 import Template
 from jupyterhub.spawner import Spawner
@@ -100,19 +105,20 @@ function selectDropdown() {
 
 
 class NubladoOptions(LoggingConfigurable):
-    async def show_options_form(self, spawner: Spawner) -> str:
-        nc = NubladoConfig()
+    def __init__(self) -> None:
+        self.nublado_config = NubladoConfig()
 
-        (cached_images, all_images) = await self._get_images_from_url(
-            nc.images_url
-        )
-        cached_images.extend(nc.pinned_images)
+    async def show_options_form(self, spawner: Spawner) -> str:
+        base_url = self.nublado_config.base_url
+        url = urljoin(base_url, "cachemachine/jupyter/available")
+        (cached_images, all_images) = await self._get_images_from_url(url)
+        cached_images.extend(self.nublado_config.pinned_images)
 
         return options_template.render(
             dropdown_sentinel=DROPDOWN_SENTINEL_VALUE,
             cached_images=cached_images,
             all_images=all_images,
-            sizes=nc.sizes.values(),
+            sizes=self.nublado_config.sizes.values(),
         )
 
     async def _get_images_from_url(


### PR DESCRIPTION
Rather than have the cachemachine URL be a separate configuration
option, derive it from the base URL the same way that the moneypenny
URL and Gafaelfawr URL are handled.  This keeps things more
consistent and will eliminate a use of the cluster-internal
cachemachine URL (which is going away so that a network policy can
be applied).