### PR TITLE
[DM-35881] Use primary GID from Gafaelfawr

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020-2022 Association of Universities for Research in Astronomy, Inc. (AURA)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,11 +3,10 @@ name = nublado2
 description = Nublado v2.
 author = Association of Universities for Research in Astronomy, Inc. (AURA)
 author_email = sqre-admin@lists.lsst.org
-long_description = file: README.rst, CHANGELOG.rst, LICENSE
+long_description = file: README.rst, LICENSE
 long_description_content_type = text/x-rst
 url = https://github.com/lsst-sqre/nublado2
 project_urls =
-    Change log = https://github.com/lsst-sqre/nublado2/master/blob/CHANGELOG.rst
     Source code = https://github.com/lsst-sqre/nublado2
     Issue tracker = https://github.com/lsst-sqre/nublado2/issues
 classifiers =
@@ -17,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Natural Language :: English
     Operating System :: POSIX
 keywords =

--- a/src/nublado2/hooks.py
+++ b/src/nublado2/hooks.py
@@ -35,7 +35,9 @@ class NubladoHooks(LoggingConfigurable):
             spawner.gid = auth_state["gid"]
         else:
             spawner.gid = spawner.uid
-        spawner.supplemental_gids = [g["id"] for g in auth_state["groups"]]
+        spawner.supplemental_gids = [
+            g["id"] for g in auth_state["groups"] if g["id"] != spawner.gid
+        ]
 
         # Since we will create a serviceaccount in the user resources,
         # make the pod use that.  This will also automount the token,

--- a/src/nublado2/hooks.py
+++ b/src/nublado2/hooks.py
@@ -25,10 +25,16 @@ class NubladoHooks(LoggingConfigurable):
 
         auth_state = await spawner.user.get_auth_state()
 
-        # We now always spawn as the target user; there is no way
-        #  to do "provisionator" anymore
+        # Gafaelfawr 5.1.0 and later will fill out the user's primary GID for
+        # GitHub and correctly-configured LDAP environments, but some
+        # configurations don't generate a GID and older versions do not.  In
+        # those cases, fall back on assuming a user private group with the
+        # same GID as the user's UID, which was the previous behavior.
         spawner.uid = auth_state["uid"]
-        spawner.gid = auth_state["uid"]
+        if "gid" in auth_state:
+            spawner.gid = auth_state["gid"]
+        else:
+            spawner.gid = spawner.uid
         spawner.supplemental_gids = [g["id"] for g in auth_state["groups"]]
 
         # Since we will create a serviceaccount in the user resources,

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -95,6 +95,7 @@ async def test_login_handler(config_mock: MagicMock) -> None:
             {
                 "username": "bar",
                 "uid": 4510,
+                "gid": 1761,
                 "groups": [
                     {"name": "group-one", "id": 1726},
                     {"name": "another", "id": 6789},
@@ -107,6 +108,7 @@ async def test_login_handler(config_mock: MagicMock) -> None:
             "auth_state": {
                 "username": "bar",
                 "uid": 4510,
+                "gid": 1761,
                 "token": "user-token",
                 "groups": [
                     {"name": "group-one", "id": 1726},


### PR DESCRIPTION
If Gafaelfawr provides a primary GID, use it.  Otherwise, fall back
on using the UID as the GID, matching the previous behavior.