### PR TITLE
[DM-36093] Update GID and group handling for Gafaelfawr changes

### DIFF
--- a/src/nublado2/hooks.py
+++ b/src/nublado2/hooks.py
@@ -35,8 +35,13 @@ class NubladoHooks(LoggingConfigurable):
             spawner.gid = auth_state["gid"]
         else:
             spawner.gid = spawner.uid
+
+        # Not all groups may have GIDs.  Only those that do contribute to the
+        # supplemental GIDs.
         spawner.supplemental_gids = [
-            g["id"] for g in auth_state["groups"] if g["id"] != spawner.gid
+            g["id"]
+            for g in auth_state["groups"]
+            if "id" in g and g["id"] != spawner.gid
         ]
 
         # Since we will create a serviceaccount in the user resources,


### PR DESCRIPTION
Skip groups for both templating and supplemental groups for the
spawned pod if the group doesn't have a GID, since GIDs will become
optional for groups.  Pass the primary GID into the template if
available, rather than only using it in the pod spawner.